### PR TITLE
Creating a remote directory, which already exists localy, does not throw an error

### DIFF
--- a/src/services/file/FileService.ts
+++ b/src/services/file/FileService.ts
@@ -50,7 +50,13 @@ export class FileService implements IFileService {
         return new Promise((resolve, reject) => {
             fs.mkdir(uri.fsPath, (err) => {
                 if(err) {
-                    reject(err);
+                    if (err.code === "EEXIST") {
+                        // Directory already exists
+                        resolve();
+                    }
+                    else {
+                        reject(err);
+                    }
                 } else {
                     resolve();
                 }


### PR DESCRIPTION
Closes #77 